### PR TITLE
Fixed "Automatic conversion of false to array is deprecated" error in php 8.1

### DIFF
--- a/fields/icomoon-base-field.php
+++ b/fields/icomoon-base-field.php
@@ -60,12 +60,13 @@ class acf_field_icomoon_base extends acf_field {
 			return $out;
 		}
 
+		$out = [];
+
 		// If not extract them from the CSS file
 		$contents = file_get_contents( $filepath );
 
 		preg_match_all( '#.icon-(.*)::before#', $contents, $css );
 		array_shift( $css );
-
 
 		foreach ( $css[0] as $cs ) {
 			$out[] = array( 'id' => $cs, 'text' => $cs );


### PR DESCRIPTION
Error: 
Deprecated: Automatic conversion of false to array is deprecated in /acf-icomoon/fields/icomoon-base-field.php on line 71

Solution: Redeclare the $out variable as an empty array.